### PR TITLE
Replace deprecated package with babel-plugin-import-graphql

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -28,6 +28,6 @@
         "preprocess": false
       }
     ],
-    "babel-plugin-inline-import-graphql-ast"
+    "import-graphql"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "build:static_export": "cross-env STATIC_EXPORT=true npm run build && cross-env STATIC_EXPORT=true next export"
   },
   "dependencies": {
-    "babel-plugin-inline-import-graphql-ast": "2.4.0",
+    "babel-plugin-import-graphql": "2.4.4",
     "babel-plugin-styled-components": "1.5.1",
     "chalk": "2.4.1",
     "color": "3.0.0",


### PR DESCRIPTION
Hi! First off, thank you for using my package. I really appreciate it.

I'm planning to do an "official" release in the next week or two, and I wasn't happy with the name I originally chose, so I've migrated it over on NPM ~~and GitHub~~. I won't be making any more updates to the original package ~~/repo~~.

I've also deprecated all versions of the original package on NPM so users will start getting deprecation notices when installing, until switching to `babel-plugin-import-graphql`.

As of version ~~`2.4.3`~~ `2.4.4`, the new package is behaviorally identical to what you are currently using. Only the `package.json`, `README.md`, `CHANGELOG.md`, and `package-lock.json` files differ. Only lines 2 and 3 (`name` and `version`) of `package-lock.json` changed. There's no new/updated dependencies or anything.