### PR TITLE
Added redux-thunk to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-redux": "6.0.0",
     "redux": "4.0.1",
     "rimraf": "2.6.3",
+    "redux-thunk": "2.3.0",
     "styled-components": "4.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
libraries/reduxStore.js:
`import thunkMiddleware from 'redux-thunk';`

The above file requires `redux-thunk` package but it is not added to `package.json` hence giving compile-time error